### PR TITLE
This is a fix to get stable_txt2img working on an M1 Mac.

### DIFF
--- a/scripts/stable_txt2img.py
+++ b/scripts/stable_txt2img.py
@@ -37,7 +37,7 @@ def load_model_from_config(config, ckpt, verbose=False):
         print("unexpected keys:")
         print(u)
 
-    model.cuda()
+#    model.cuda()
     model.eval()
     return model
 
@@ -195,7 +195,13 @@ def main():
     model = load_model_from_config(config, f"{opt.ckpt}")
     #model.embedding_manager.load(opt.embedding_path)
 
-    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+#    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    if torch.cuda.is_available(): 
+        device = torch.device("cuda")
+    elif torch.backends.mps.is_built():
+        device = torch.device("mps")
+    else :
+        device = torch.device("cpu")
     model = model.to(device)
 
     if opt.plms:


### PR DESCRIPTION
- Install Stable Diffusion as per [https://medium.com/gft-engineering/macbook-m1-how-to-install-and-run-stable-diffusion-7bfb2f802b1a](https://medium.com/gft-engineering/macbook-m1-how-to-install-and-run-stable-diffusion-7bfb2f802b1a)
- Install PyTorch by running : 
- `conda install pytorch torchvision torchaudio -c pytorch-nightly`

Running with more than one sample seems to break it so I'm just running multiple itterations to get the regularization images:
`python scripts/stable_txt2img.py --ddim_eta 0.0 --n_samples 1 --n_iter 200 --scale 10.0 --ddim_steps 50 --ckpt ~/Downloads/sd-v1-4-full-ema.ckpt --prompt "a photo of a <class>`